### PR TITLE
feat: Track rooms & Use Map() to track rooms and users

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,11 @@
     "env": {
         "node": true,
         "commonjs": true,
-        "es2021": true
+        "es2020": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 12
+        "ecmaVersion": 1a
     },
     "rules": {
         "accessor-pairs": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,11 +2,11 @@
     "env": {
         "node": true,
         "commonjs": true,
-        "es2020": true
+        "es2021": true
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 11
+        "ecmaVersion": 12
     },
     "rules": {
         "accessor-pairs": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,7 @@
     },
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 1a
+        "ecmaVersion": 11
     },
     "rules": {
         "accessor-pairs": "error",

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo npm install ps-client
 
 If you have it in your package.json, simply run ``npm install``. If you have installed it and wish to update your version, run ``sudo npm update ps-client``.
 
-PS-Client requires **Node.js v14.0.0 or higher**.
+PS-Client requires **Node.js v16.0.0 or higher**.
 
 
 
@@ -101,8 +101,8 @@ Client is an instance of an EventEmitter, and is the primary class. You can gene
 Client has the following properties:
 * `opts`: An object containing most of the configuration options. Note that Client.opts.password is a function that returns the password instead of a string.
 * `isTrusted`: A boolean that indicates whether the Bot is running on a trusted account. Until this is received, this value is null.
-* `rooms`: An object containing all the rooms the Bot is in. The keys are the room IDs, while the values are [Room](#room-structure) instances.
-* `users`: An object containing all the users the Bot is aware of. The keys are the user IDs, while the values are [User](#user-structure) instances.
+* `rooms`: An Map containing all the rooms the Bot is in. The keys are the room IDs, while the values are [Room](#room-structure) instances.
+* `users`: An Map containing all the users the Bot is aware of. The keys are the user IDs, while the values are [User](#user-structure) instances.
 * `status`: An object containing four keys regarding the status of the connection. These are: ``connected``, which is a Boolean that indicates whether the Bot is currently connected, ``loggedIn``: a boolean that indicates whether the Bot has logged in successfully, ``username``, which is the username the Bot has connected under, and ``userid``, the corresponding user ID.
 * `closed`: A boolean that indicates whether the connection is currently closed.
 * `debug`, `handle`: These are where the debug and handler functions are stored.
@@ -111,12 +111,16 @@ Client also has the following methods:
 * `connect (reconnect: boolean): void` - Creates the websocket to connect to the server, then logs in. ``reconnect`` has no significance besides logging the attempt as a reconnection attempt.
 * `disconnect: void` - Closes the connection.
 * `login (username: string, password: string | undefined): void` - Logs in with the given credentials. Requires the websocket to have been created.
-* `getUser (username: string | User): User | false | null` - Finds a user among tracked users. Returns the user instance (in case the user has been tracked while renaming, the new User instance). Returns `null` for an invalid input and `false` if the user is not tracked.
+* `getUser (username: string | User): User | false | null` - Finds a user among cached users. Returns the user instance (in case the user has been cached while renaming, the new User instance). Returns `null` for an invalid input and `false` if the user is not cached.
+* `fetchUser (userid: string): Promise<User>` - Fetches a user via internet. Returns the user instance. In case the user is offline, property 'rooms' becames false.
+* `getRoom` (roomid: string): Room | false | null - Finds a room among cached rooms. Returns the room instance (in case the room has been cached while renaming, the new Room instance). Returns `null` for an invalid input or not existing room or missing permission. And `false` if the user is not cached.
+* `fetchRoom (roomid: string): Promise<?Room>` - Fetches a room via internet. Returns the room instance. In case the user isn't exist, returns `undefined`.
 * `sendUser (username: string | User, text: string): Promise<Message>` - Sends the provided string to the specified user.
 * `send (text: string): void` - Sends the provided string to the server. This bypasses the queue, and can cause the Bot to exceed the throttle. **Using Room#send or User#send instead is highly recommended.**
 
 Client has the following events:
 
+* `loggedin (username: string)` - Emitted whenever the Client logged on.
 * `message (message: Message)` - Emitted whenever a message is received (includes both chat and PMs).
 * `join (room: string, user: string, isIntro: boolean)` - Emitted whenever a user joins a room.
 * `leave (room: string, user: string, isIntro: boolean)` - Emitted whenever a user leaves a room.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo npm install ps-client
 
 If you have it in your package.json, simply run ``npm install``. If you have installed it and wish to update your version, run ``sudo npm update ps-client``.
 
-PS-Client requires **Node.js v16.0.0 or higher**.
+PS-Client requires **Node.js v14.0.0 or higher**.
 
 
 

--- a/classes/message.js
+++ b/classes/message.js
@@ -5,7 +5,7 @@ const { toID } = require('../tools.js');
 class Message {
 	constructor (input) {
 		let { by, text, type, target, raw, isIntro, parent, time } = input;
-		by = toID(by);
+		if (!['~', '&'].includes(by)) by = toID(by);
 		if (!parent.users.has(by)) {
 			parent.addUser({ userid: by });
 			parent.fetchUser(by);

--- a/classes/message.js
+++ b/classes/message.js
@@ -6,11 +6,11 @@ class Message {
 	constructor (input) {
 		let { by, text, type, target, raw, isIntro, parent, time } = input;
 		by = toID(by);
-		if (!parent.users[by]) {
+		if (!parent.users.has(by)) {
 			parent.addUser({ userid: by });
 			parent.fetchUser(by);
 		}
-		this.author = parent.users[by];
+		this.author = parent.users.get(by);
 		this.content = text;
 		let match = text.match(/^[/!][^ ]+/);
 		if (match) this.command = match[0];
@@ -24,10 +24,10 @@ class Message {
 		else this.time = Date.now();
 		switch (this.type) {
 			case 'chat':
-				this.target = this.parent.rooms[target];
+				this.target = this.parent.rooms.get(target);
 				break;
 			case 'pm':
-				this.target = this.parent.users[target];
+				this.target = this.parent.users.get(target);
 				break;
 			default: console.error(this.type);
 		}

--- a/classes/message.js
+++ b/classes/message.js
@@ -8,7 +8,7 @@ class Message {
 		by = toID(by);
 		if (!parent.users[by]) {
 			parent.addUser({ userid: by });
-			parent.getUserDetails(by);
+			parent.fetchUser(by);
 		}
 		this.author = parent.users[by];
 		this.content = text;

--- a/classes/room.js
+++ b/classes/room.js
@@ -17,14 +17,14 @@ class Room {
 		});
 	}
 	privateSend (user, text) {
-		if (!['*', '#', '&'].includes(this.users.find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
+		if (!['*', '#', '&'].includes([...this.users.values()].find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
 		user = this.parent.getUser(user);
 		if (!user) return false;
 		this.send(`/sendprivatehtmlbox ${user.userid}, ${Tools.escapeHTML(text)}`);
 		return true;
 	}
 	sendHTML (html, opts = {}) {
-		if (!['*', '#', '&'].includes(this.users.find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
+		if (!['*', '#', '&'].includes([...this.users.values()].find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
 		if (!html) throw new Error("Missing HTML argument");
 		if (typeof opts === 'string') opts = { name: opts };
 		if (!opts || typeof opts !== 'object') throw new TypeError("Options must be an object");
@@ -40,12 +40,12 @@ class Room {
 		return true;
 	}
 	privateHTML (user, html, opts = {}) {
-		if (!['*', '#', '&'].includes(this.users.find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
+		if (!['*', '#', '&'].includes([...this.users.values()].find(u => Tools.toID(u) === this.parent.status.userid)?.charAt(0))) return false;
 		user = this.parent.getUser(user);
 		if (!user) return false;
 		if (!html) throw new Error("Missing HTML argument");
 		if (typeof opts === 'string') opts = { name: opts };
-		if (!opts || typeof opts !== 'object') throw new TypeError("Options must be an object");
+		if (!opts || typeof opts !== 'object') throw new TypeError('Options must be an object');
 		if (!opts.name) opts.name = this.parent.status.username + Date.now().toString(36);
 		inlineCss(html, {
 			url: 'filePath'

--- a/classes/user.js
+++ b/classes/user.js
@@ -4,7 +4,7 @@ const inlineCss = require('inline-css');
 
 class User {
 	constructor (init, parent) {
-		Object.keys(init).forEach(key => this[key] = init[key]);
+    Object.assign(this, init);
 		this.parent = parent;
 		this._waits = [];
 		this.alts = [];

--- a/classes/user.js
+++ b/classes/user.js
@@ -4,7 +4,7 @@ const inlineCss = require('inline-css');
 
 class User {
 	constructor (init, parent) {
-    Object.assign(this, init);
+		Object.assign(this, init);
 		this.parent = parent;
 		this._waits = [];
 		this.alts = [];

--- a/classes/user.js
+++ b/classes/user.js
@@ -21,12 +21,12 @@ class User {
 		if (typeof opts === 'string') opts = { name: opts };
 		if (!opts || typeof opts !== 'object') throw new TypeError("Options must be an object");
 		if (!opts.name) opts.name = this.parent.status.username + Date.now().toString(36);
-		const rooms = {};
-		Object.values(this.parent.rooms).forEach(room => {
+		const rooms = new Map();
+		[...this.parent.rooms.values()].forEach(room => {
 			if (
 				room.auth?.['*']?.includes(this.parent.status.userid) ||
 				room.auth?.['#']?.includes(this.parent.status.userid)
-			) rooms[room.visibility] = room;
+			) rooms.set(room.visibility, room);
 		});
 		const room = rooms.public || rooms.hidden || rooms.private;
 		if (!room) return false;
@@ -43,12 +43,12 @@ class User {
 		if (!html) throw new Error("Missing HTML argument");
 		if (!name) name = this.parent.status.username + Date.now().toString(36);
 		name = name.toString();
-		const rooms = {};
-		Object.values(this.parent.rooms).forEach(room => {
+		const rooms = new Map();
+		[...this.parent.rooms.values()].forEach(room => {
 			if (
 				room.auth?.['*']?.includes(this.parent.status.userid) ||
 				room.auth?.['#']?.includes(this.parent.status.userid)
-			) rooms[room.visibility] = room;
+			) rooms.set(room.visibility, room);
 		});
 		const room = rooms.public || rooms.hidden || rooms.private;
 		if (!room) return false;

--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ class Client extends EventEmitter {
 							}
 						}
 						if (!this.rooms.has(roominfo.roomid)) break;
-						this.rooms.set(roominfo.roomid, Object.assign(new Room(roominfo.roomid, this), roominfo);
+						this.rooms.set(roominfo.roomid, Object.assign(new Room(roominfo.roomid, this), roominfo));
 						if (room) room.resolve(roominfo);
 						roominfo.users.forEach(user => this.fetchUser(user).catch(this.handle));
 						break;

--- a/index.js
+++ b/index.js
@@ -576,7 +576,7 @@ class Client extends EventEmitter {
 		const client = this;
 		return new Promise(resolve => {
 			this.send(`|/cmd roominfo ${roomid}`);
-			client._roomInfoQueue.push({ id: roomid, resolve: resolve });
+			client._roominfoQueue.push({ id: roomid, resolve: resolve });
 		});
 	}
 }

--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ class Client extends EventEmitter {
 							}
 						}
 						if (!this.rooms.has(roominfo.roomid)) break;
-						this.rooms.set(roominfo.roomid, new Room(roominfo.roomid, this));
+						this.rooms.set(roominfo.roomid, Object.assign(new Room(roominfo.roomid, this), roominfo);
 						if (room) room.resolve(roominfo);
 						roominfo.users.forEach(user => this.fetchUser(user).catch(this.handle));
 						break;

--- a/index.js
+++ b/index.js
@@ -161,7 +161,7 @@ class Client extends EventEmitter {
 					return;
 				}
 				try {
-					data = JSON.parse(data.substr(1));
+					data = JSON.parse(data.substring(1));
 					if (data.actionsuccess) data = data.assertion;
 					else {
 						client.handle(`Unable to login: ${JSON.stringify(data)}`);
@@ -244,11 +244,11 @@ class Client extends EventEmitter {
 
 	// Receiving data
 	receive (message) {
-		const flag = message.substr(0, 1);
+		const flag = message.substring(0, 1);
 		let data;
 		switch (flag) {
 			case 'a':
-				data = JSON.parse(message.substr(1));
+				data = JSON.parse(message.substring(1));
 				if (data instanceof Array) {
 					for (let i = 0; i < data.length; i++) {
 						this.receiveMsg(data[i]);
@@ -265,7 +265,7 @@ class Client extends EventEmitter {
 			const spl = message.split('\n');
 			let room = 'lobby';
 			if (spl[0].charAt(0) === '>') {
-				room = spl[0].substr(1);
+				room = spl[0].substring(1);
 				if (room === '') room = 'lobby';
 			}
 			for (let i = 0, len = spl.length; i < len; i++) {
@@ -292,7 +292,7 @@ class Client extends EventEmitter {
 			}
 			case 'updateuser': {
 				if (!args[2].startsWith(' Guest')) {
-					this.debug(`Successfully logged in as ${args[2].substr(1)}.`);
+					this.debug(`Successfully logged in as ${args[2].substring(1)}.`);
 					this.status.loggedIn = true;
 					this.emit('loggedin', args[2]);
 					this.send('|/ip');
@@ -300,7 +300,7 @@ class Client extends EventEmitter {
 					if (this.opts.avatar) this.send(`|/avatar ${this.opts.avatar}`);
 					if (this.opts.status) this.send(`|/status ${this.opts.status}`);
 				}
-				this.status.username = args[2].substr(1);
+				this.status.username = args[2].substring(1);
 				this.status.userid = Tools.toID(this.status.username);
 				this.emit('updateuser', room, args.slice(2).join('|'), isIntro);
 				break;
@@ -397,7 +397,7 @@ class Client extends EventEmitter {
 						}
 					});
 					mssg.target._waits = mssg.target._waits.filter(wait => !resolved.includes(wait.id));
-					if (by.substr(1) === this.status.username) {
+					if (by.substring(1) === this.status.username) {
 						if (this._queued.map(msg => msg.content).includes(value)) {
 							while (this._queued.length) {
 								const msg = this._queued.shift();
@@ -432,7 +432,7 @@ class Client extends EventEmitter {
 					}
 				});
 				mssg.target._waits = mssg.target._waits.filter(wait => !resolved.includes(wait.id));
-				if (!isIntro && by.substr(1) === this.status.username && this._queued.map(msg => msg.content).includes(comp)) {
+				if (!isIntro && by.substring(1) === this.status.username && this._queued.map(msg => msg.content).includes(comp)) {
 					while (this._queued.length) {
 						const msg = this._queued.shift();
 						if (msg.content === comp) {
@@ -447,7 +447,7 @@ class Client extends EventEmitter {
 			}
 			case 'pm': {
 				let by = args[2], to = args[3], value = args.slice(4).join('|'), chatWith, resolved = [];
-				if (by.substr(1) === this.status.username) chatWith = to;
+				if (by.substring(1) === this.status.username) chatWith = to;
 				else chatWith = by;
 				const mssg = new Message({
 					by: by,
@@ -459,7 +459,7 @@ class Client extends EventEmitter {
 					parent: this,
 					time: Date.now()
 				}), comp = `|/pm ${Tools.toID(to)},${value}`;
-				if (mssg.command && mssg.command === 'error') mssg.target._waits.shift().fail(mssg.content.substr(7));
+				if (mssg.command && mssg.command === 'error') mssg.target._waits.shift().fail(mssg.content.substring(7));
 				if (mssg.target) {
 					mssg.target._waits.forEach(wait => {
 						if (wait.condition(mssg)) {
@@ -469,7 +469,7 @@ class Client extends EventEmitter {
 						}
 					});
 					mssg.target._waits = mssg.target._waits.filter(wait => !resolved.includes(wait.id));
-					if (!isIntro && by.substr(1) === this.status.username && this._queued.map(msg => msg.content).includes(comp)) {
+					if (!isIntro && by.substring(1) === this.status.username && this._queued.map(msg => msg.content).includes(comp)) {
 						while (this._queued.length) {
 							const msg = this._queued.shift();
 							if (msg.content === comp) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ class Client extends EventEmitter {
 		this._queue = [];
 		this._queued = [];
 		this._userdetailsQueue = [];
-    this._roominfoQueue = [];
+		this._roominfoQueue = [];
 
 		this.debug = opts.debug ? console.log : () => {};
 		this.handle = opts.handle === null ? () => {} : (typeof opts.handle === 'function' ? opts.handle : console.error);
@@ -315,12 +315,12 @@ class Client extends EventEmitter {
 			}
 			case 'init': {
 				if (!this.rooms.has(room)) this.rooms.set(room, new Room(room, this));
-        room = await this.fetchRoom(room);
+				room = await this.fetchRoom(room);
 				this.emit('joinRoom', room);
 				break;
 			}
 			case 'deinit': {
-        room = this.getRoom(room) ?? room;
+				room = this.getRoom(room) ?? room;
 				this.emit('leaveRoom', room);
 				break;
 			}
@@ -350,7 +350,7 @@ class Client extends EventEmitter {
 								break;
 							}
 						}
-            this.rooms.set(roominfo.roomid, roominfo);
+						this.rooms.set(roominfo.roomid, roominfo);
 						if (room) room.resolve(roominfo);
 						roominfo.users.forEach(user => this.fetchUser(user).catch(this.handle));
 						break;
@@ -362,7 +362,7 @@ class Client extends EventEmitter {
 						} catch (e) {
 							this.handle(`Error in parsing userdetails: ${e.message}`);
 						}
-            if (!userdetails.userid) userdetails.userid ??= "&";
+						if (!userdetails.userid) userdetails.userid ??= "&";
 						this.addUser(userdetails);
 						let user;
 						for (let u of this._userdetailsQueue) {
@@ -371,7 +371,7 @@ class Client extends EventEmitter {
 								break;
 							}
 						}
-            this.users.set(userdetails.id, userdetails)
+						this.users.set(userdetails.id, userdetails)
 						if (user) user.resolve(userdetails);
 						break;
 					}
@@ -494,7 +494,7 @@ class Client extends EventEmitter {
 			}
 			case 'j': case 'J': case 'join': {
 				this.addUser({ userid: Tools.toID(args.slice(2).join('|')) });
-        room = await this.fetchRoom(room)
+				room = await this.fetchRoom(room)
 				this.emit('join', room, args.slice(2).join('|'), isIntro);
 				break;
 			}
@@ -515,7 +515,7 @@ class Client extends EventEmitter {
 				break;
 			}
 			case 'error': {
-        room = this.getRoom(room);
+				room = this.getRoom(room);
 				this.emit('chaterror', room, args.slice(2).join('|'), isIntro);
 				break;
 			}
@@ -535,11 +535,11 @@ class Client extends EventEmitter {
 		Object.keys(input).forEach(key => user[key] = input[key])
 		return user;
 	}
-  addRoom (input) {
+	addRoom (input) {
 		if (typeof input !== 'object' || !input.roomid) throw new Error ("Input must be an object with roomid for new Room");
 		let room = this.rooms.get(input.userid);
 		if (!room) {
-      this.users.set(input.roomid, new Room (input, this));
+			this.users.set(input.roomid, new Room (input, this));
 			room = this.rooms.get(input.userid);
 			this.fetchRoom(input.roomid);
 		}
@@ -550,7 +550,7 @@ class Client extends EventEmitter {
 		if (str instanceof User) str = str.userid;
 		if (typeof str !== 'string') return null;
 		str = Tools.toID(str);
-    if (this.users.has(str)) return this.users.get(str);
+		if (this.users.has(str)) return this.users.get(str);
 		for (const user of [...this.users.values()]) {
 			if (user.alts?.includes(str)) return user;
 		}
@@ -564,18 +564,18 @@ class Client extends EventEmitter {
 			client._userdetailsQueue.push({ id: userid, resolve: resolve });
 		});
 	}
-  getRoom (str) {
+	getRoom (str) {
 		if (str instanceof Room) str = str.roomid;
 		if (typeof str !== 'string') return null;
 		str = Tools.toID(str);
 		if (!this.rooms.has(str)) return false;
-    return this.rooms.get(str);
+		return this.rooms.get(str);
 	}
-  fetchRoom (roomid) {
+	fetchRoom (roomid) {
 		roomid = Tools.toID(roomid);
 		const client = this;
 		return new Promise(resolve => {
-      this.send(`|/cmd roominfo ${roomid}`);
+			this.send(`|/cmd roominfo ${roomid}`);
 			client._roomInfoQueue.push({ id: roomid, resolve: resolve });
 		});
 	}

--- a/index.js
+++ b/index.js
@@ -366,7 +366,7 @@ class Client extends EventEmitter {
 						} catch (e) {
 							this.handle(`Error in parsing userdetails: ${e.message}`);
 						}
-						if ([undefined, null, 0]?.includes(userdetails?.userid?.length)) break;
+						if (!userdetails?.userid || userdetails?.userid?.length === 0) break;
 						this.addUser(userdetails);
 						let user;
 						for (let u of this._userdetailsQueue) {
@@ -561,8 +561,9 @@ class Client extends EventEmitter {
 		return false;
 	}
 	fetchUser (userid) {
+    if (typeof userid !== 'string') return null;
 		userid = Tools.toID(userid);
-		if ([undefined, null, 0]?.includes(userid?.length)) return;
+		if (userid.length === 0) return null;
 		const client = this;
 		return new Promise(resolve => {
 			this.send(`|/cmd userdetails ${userid}`);

--- a/index.js
+++ b/index.js
@@ -362,6 +362,7 @@ class Client extends EventEmitter {
 						} catch (e) {
 							this.handle(`Error in parsing userdetails: ${e.message}`);
 						}
+            if (!userdetails.userid) userdetails.userid ??= "&";
 						this.addUser(userdetails);
 						let user;
 						for (let u of this._userdetailsQueue) {

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class Client extends EventEmitter {
 		this.webSocket = webSocket;
 		const client = this;
 		client.rooms.clear(); // reset
-    client.users.clear();
+		client.users.clear();
 		['~', '&'].forEach(e => client.users.set(e, new User({ id: e, userid: e, name: e, rooms: false }, client)));
 		webSocket.on('connectFailed', function (err) {
 				client.emit('disconnect', err);
@@ -284,7 +284,7 @@ class Client extends EventEmitter {
 			this.receiveLine('lobby', message);
 		}
 	}
-  receiveLine (room, message, isIntro) {
+	receiveLine (room, message, isIntro) {
 		this.emit('line', room, message, isIntro);
 		const args = message.split('|');
 		switch (args[1]) {
@@ -344,7 +344,7 @@ class Client extends EventEmitter {
 						} catch (e) {
 							this.handle(`Error in parsing roominfo: ${e.message}`);
 						}
-            if (roominfo.error) console.error(roominfo.error);
+						if (roominfo.error) console.error(roominfo.error);
 						this.addRoom(roominfo);
 						let room;
 						for (let r of this._roominfoQueue) {
@@ -497,7 +497,7 @@ class Client extends EventEmitter {
 				break;
 			}
 			case 'j': case 'J': case 'join': {
-        this.send(`|/cmd roominfo ${room}`);
+				this.send(`|/cmd roominfo ${room}`);
 				this.addUser({ userid: Tools.toID(args.slice(2).join('|')) });
 				this.emit('join', room, args.slice(2).join('|'), isIntro);
 				break;
@@ -528,11 +528,11 @@ class Client extends EventEmitter {
 
 	// Utility
 	addUser (input) {
-    if (input?.userid?.length === 0) return;
+		if (input?.userid?.length === 0) return;
 		if (typeof input !== 'object' || !input.userid) throw new Error ("Input must be an object with userid for new User");
 		let user = this.users.get(input.userid);
 		if (!user) {
-      this.users.set(input.userid, new User (input, this));
+			this.users.set(input.userid, new User (input, this));
 			user = this.users.get(input.userid);
 			this.fetchUser(input.userid);
 		}
@@ -562,7 +562,7 @@ class Client extends EventEmitter {
 	}
 	fetchUser (userid) {
 		userid = Tools.toID(userid);
-    if ([undefined, null, 0]?.includes(userid?.length)) return;
+		if ([undefined, null, 0]?.includes(userid?.length)) return;
 		const client = this;
 		return new Promise(resolve => {
 			this.send(`|/cmd userdetails ${userid}`);

--- a/index.js
+++ b/index.js
@@ -511,7 +511,7 @@ class Client extends EventEmitter {
 				this.users.get(old).alts.push(yng);
 				this.users.set(yng, this.users.get(old));
 				this.users.delete(old);
-				this.getUserDetails(yng);
+				this.fetchUser(yng);
 				break;
 			}
 			case 'error': {
@@ -539,8 +539,8 @@ class Client extends EventEmitter {
 		if (typeof input !== 'object' || !input.roomid) throw new Error ("Input must be an object with roomid for new Room");
 		let room = this.rooms.get(input.userid);
 		if (!room) {
-			this.users.set(input.roomid, new Room (input, this));
-			room = this.rooms.get(input.userid);
+			this.users.set(input.roomid, new Room (input.roomid, this));
+			room = this.rooms.get(input.roomid);
 			this.fetchRoom(input.roomid);
 		}
 		Object.keys(input).forEach(key => room[key] = input[key]);


### PR DESCRIPTION
## PR Checklist
- [x] This PR includes destructive changes.
- [x] I have tested changes by bot.
- [ ] I received all event by bot.
## Description
- Use Map() to tracking users
  - refactor: Rename `Client.getUserDetails` to `Client.fetchRoom`
  - refactor: `Client.getUser`
- Tracking rooms
  - feat: Add `Client.addRoom`
  - feat: Add `Client.getRoom`
  - feat: Add `Client.fetchRoom`
  - update: exec `Client.addRoom` when received roominfo.
 - Bug fixes
   - fix: fix crash when received mod message (mod message is supposed to be sent by &, so it crashes when exec addUser)

## Why Map() ?

When execed `console.log(new Client(opts));` (after connected), got too many Objects of Users, and Rooms.
But using Map(), you can pick specified data to easy (like `Client.rooms.get("key")`, `Client.rooms.set("key", "value")`, `[…Client.rooms.values()]`, `Client.rooms.size`).
