### PR TITLE
Add an option to choose websocket protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ type options = {
 	password?: string, // The password for the username you're connecting to. Leave this blank if the account is unregistered.
 	server?: string, // The server to which you wish to connect to - defaults to 'sim3.psim.us'.
 	port?: number, // The port on which you're connecting to. Can also be specified in server as `url:port`, in which case leave this field blank.
-	serverProtocol?: number, // The protocol used for the websocket connection. Defaults to wss, but can be changed to ws (insecure).
+	serverProtocol?: string, // The protocol used for the websocket connection. Defaults to wss, but can be changed to ws (insecure).
 	connectionTimeout?: number, // The time, in milliseconds, after which your connection times out. Defaults to 20s.
 	loginServer?: string, // The login server. Defaults to 'https://play.pokemonshowdown.com/~~showdown/action.php'.
 	avatar?: string | number, // The avatar your Bot will have on connection. If not specified, PS will set one randomly.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ type options = {
 	password?: string, // The password for the username you're connecting to. Leave this blank if the account is unregistered.
 	server?: string, // The server to which you wish to connect to - defaults to 'sim3.psim.us'.
 	port?: number, // The port on which you're connecting to. Can also be specified in server as `url:port`, in which case leave this field blank.
+	serverProtocol?: number, // The protocol used for the websocket connection. Defaults to wss, but can be changed to ws (insecure).
 	connectionTimeout?: number, // The time, in milliseconds, after which your connection times out. Defaults to 20s.
 	loginServer?: string, // The login server. Defaults to 'https://play.pokemonshowdown.com/~~showdown/action.php'.
 	avatar?: string | number, // The avatar your Bot will have on connection. If not specified, PS will set one randomly.

--- a/client.d.ts
+++ b/client.d.ts
@@ -21,7 +21,7 @@ type ClientOpts = {
 	server?: string,
 	serverid?: string,
 	port?: number,
-  serverProtocol: string,
+	serverProtocol: string,
 	loginServer?: string
 };
 

--- a/client.d.ts
+++ b/client.d.ts
@@ -21,6 +21,7 @@ type ClientOpts = {
 	server?: string,
 	serverid?: string,
 	port?: number,
+  serverProtocol: string,
 	loginServer?: string
 };
 

--- a/client.d.ts
+++ b/client.d.ts
@@ -21,7 +21,7 @@ type ClientOpts = {
 	server?: string,
 	serverid?: string,
 	port?: number,
-	serverProtocol: string,
+	serverProtocol?: string,
 	loginServer?: string
 };
 

--- a/client.js
+++ b/client.js
@@ -18,6 +18,7 @@ class Client extends EventEmitter {
 		this.opts = {
 			server: 'sim3.psim.us',
 			serverid: 'showdown',
+			serverProtocol: 'wss',
 			connectionTimeout: 20_000,
 			loginServer: 'https://play.pokemonshowdown.com/action.php',
 			username: null,
@@ -122,7 +123,8 @@ class Client extends EventEmitter {
 		const id = ~~(Math.random() * 900) + 100;
 		const chars = 'abcdefghijklmnopqrstuvwxyz0123456789_'.split('');
 		const str = Array.from({ length: 8 }, () => chars[~~(Math.random() * 36)]).join('');
-		const conStr = `wss://${this.opts.server}${this.opts.port ? `:${this.opts.port}` : ''}/showdown/${id}/${str}/websocket`;
+		const conStr = `${this.opts.serverProtocol}://${this.opts.server}\
+${this.opts.port ? `:${this.opts.port}` : ''}/showdown/${id}/${str}/websocket`;
 		this.debug(`Connecting to ${conStr}`);
 		webSocket.connect(conStr);
 	}

--- a/client.js
+++ b/client.js
@@ -123,8 +123,8 @@ class Client extends EventEmitter {
 		const id = ~~(Math.random() * 900) + 100;
 		const chars = 'abcdefghijklmnopqrstuvwxyz0123456789_'.split('');
 		const str = Array.from({ length: 8 }, () => chars[~~(Math.random() * 36)]).join('');
-		const conStr = `${this.opts.serverProtocol}://${this.opts.server}\
-${this.opts.port ? `:${this.opts.port}` : ''}/showdown/${id}/${str}/websocket`;
+		const { server, serverProtocol, port } = this.opts;
+		const conStr = `${serverProtocol}://${server}${port ? `:${port}` : ''}/showdown/${id}/${str}/websocket`;
 		this.debug(`Connecting to ${conStr}`);
 		webSocket.connect(conStr);
 	}

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ dotenv.config();
 const { Client, Tools, Data } = require('../client.js');
 
 const Bot = new Client({
-	username: process.env.USERNAME ?? 'PS-Client',
+	username: process.env.PS_USERNAME ?? 'PS-Client',
 	password: process.env.PASSWORD,
 	rooms: ['botdevelopment'],
 	debug,

--- a/test/index.js
+++ b/test/index.js
@@ -9,7 +9,7 @@ dotenv.config();
 const { Client, Tools, Data } = require('../client.js');
 
 const Bot = new Client({
-	username: 'PS-Client',
+	username: process.env.USERNAME ?? 'PS-Client',
 	password: process.env.PASSWORD,
 	rooms: ['botdevelopment'],
 	debug,


### PR DESCRIPTION
Now that wss is the default this change is needed to support insecure servers

Needed the tests change for the pre-commit hook to work 

- **tests: Allow running tests under different account names** 
- **feat: Add server protocol to Client**
